### PR TITLE
fix: resolve ruff lint errors

### DIFF
--- a/django_whoop/admin.py
+++ b/django_whoop/admin.py
@@ -1,7 +1,17 @@
 from django.contrib import admin
 
 # Register your models here.
-from .models import *
+from .models import (
+    Daily,
+    HR,
+    JournalEntry,
+    Recovery,
+    Sleep,
+    SleepDetail,
+    Strain,
+    WhoopUser,
+    Workout,
+)
 
 
 @admin.register(WhoopUser)

--- a/django_whoop/views.py
+++ b/django_whoop/views.py
@@ -7,7 +7,21 @@ from django.http import HttpRequest, HttpResponseRedirect
 from django.shortcuts import redirect, render
 import requests
 
-from .models import *
+import datetime
+
+import pytz
+from django.db import models
+
+from .models import (
+    Daily,
+    HR,
+    JournalEntry,
+    Recovery,
+    Sleep,
+    Strain,
+    WhoopUser,
+    Workout,
+)
 from .forms import WhoopAuthForm
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-whoop"
-version = "0.1.2"
+version = "0.1.3"
 description = "A Django app to access WHOOP Web APIs."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { text = "BSD-3-Clause" }

--- a/scripts/bulk_load.py
+++ b/scripts/bulk_load.py
@@ -1,3 +1,4 @@
+# ruff: noqa: F405
 ## this helps with weird ipython completion error
 # get_ipython().run_line_magic('config', 'IPCompleter.use_jedi = False')
 
@@ -8,22 +9,22 @@ import sys
 
 sys.path.insert(0, str(Path(sys.path[0]) / "../.."))
 print(sys.path)
-import os
+import os  # noqa: E402
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "main.settings")
 # from asgiref.sync import sync_to_async
 os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
-import django
+import django  # noqa: E402
 
 django.setup()
 
 ## completed django setup
 
 
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User  # noqa: E402
 
-from django_whoop.models import *
-from django_whoop.views import *
+from django_whoop.models import *  # noqa: F403, E402
+from django_whoop.views import *  # noqa: F403, E402
 
 user = User.objects.get(username="andyreagan")
 user.whoopuser.refreshIfNeeded()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -361,7 +361,7 @@ class TestRecoveryModel:
     def test_create_and_retrieve(self):
         wu = make_whoop_user()
         daily = make_daily(wu)
-        r = Recovery.objects.create(
+        Recovery.objects.create(
             day=daily,
             id=60001,
             heartRateVariabilityRmssd=0.059,
@@ -484,7 +484,7 @@ class TestJournalEntry:
         assert "Intermittent Fasting" in str(entry)
 
     def test_create_from_response(self):
-        daily = self._make_daily()
+        self._make_daily()
         raw = {
             "behavior_tracker": {
                 "id": 50,


### PR DESCRIPTION
Fix ruff lint errors:

- F403/F405: replace `from .models import *` with explicit imports in admin.py and views.py
- F841: remove unused variable assignments in tests
- E402/F403: add noqa comments in scripts/bulk_load.py (requires sys.path setup before imports)
- Add missing `datetime`, `pytz`, `models` imports in views.py