### PR TITLE
chore: monthly maintenance — March 2026

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Install Python
         run: uv python install ${{ matrix.python-version }}
@@ -41,10 +41,10 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Install Python
         run: uv python install

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,10 +10,10 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Install Python
         run: uv python install


### PR DESCRIPTION
Automated monthly maintenance for **django-whoop**.

### Steps
- ✅ update github actions: actions/checkout: v4→v6, astral-sh/setup-uv: v5→v7
- ✅ pre-commit autoupdate
- ✅ pre-commit run --all-files
- ✅ uv lock --upgrade: Resolved 24 packages in 82ms

- ✅ uv sync
- ✅ uv run pytest

Dependency lag date: `2026-03-06`

Generated by `maintain.py` on 2026-03-13.