### PR TITLE
chore: monthly maintenance — March 2026

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.6
+    rev: v0.15.7
     hooks:
       - id: ruff
         args: [--fix]


### PR DESCRIPTION
Automated monthly maintenance for **django-whoop**.

### Steps
- ⏭️ update github actions: already up to date
- ✅ pre-commit autoupdate
- ✅ pre-commit run --all-files
- ✅ uv lock --upgrade: Resolved 24 packages in 218ms

- ✅ uv sync
- ✅ uv run pytest

Dependency lag date: `2026-03-16`

Generated by `maintain.py` on 2026-03-23.